### PR TITLE
[WO-554] use 7bit transfer encoding for PGP payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "http://github.com/whiteout-io/pgpbuilder.git"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "licenses": [{
     "type": "MIT",
     "url": "http://github.com/whiteout-io/pgpbuilder/blob/master/LICENSE"

--- a/src/pgpbuilder.js
+++ b/src/pgpbuilder.js
@@ -266,6 +266,7 @@ define(function(require) {
             var signatureHeader = '-----BEGIN PGP SIGNATURE-----';
             var signature = signatureHeader + signedCleartext.split(signatureHeader).pop();
             var signatureNode = rootNode.createChild('application/pgp-signature');
+            signatureNode.setHeader('content-transfer-encoding', '7bit');
             signatureNode.setContent(signature);
 
             signedBodyPartRoot.message = cleartext;
@@ -279,17 +280,20 @@ define(function(require) {
         // creates an encrypted pgp/mime message with a top-level multipart/encrypted node
         rootNode.setHeader('content-type', 'multipart/encrypted; protocol=application/pgp-encrypted');
         rootNode.setHeader('content-description', 'OpenPGP encrypted message');
+        rootNode.setHeader('content-transfer-encoding', '7bit');
         rootNode.setContent('This is an OpenPGP/MIME encrypted message.');
 
         // set the version info
         var versionNode = rootNode.createChild('application/pgp-encrypted');
         versionNode.setHeader('content-description', 'PGP/MIME Versions Identification');
+        versionNode.setHeader('content-transfer-encoding', '7bit');
         versionNode.setContent('Version: 1');
 
         // set the ciphertext
         var ctNode = rootNode.createChild('application/octet-stream');
         ctNode.setHeader('content-description', 'OpenPGP encrypted message');
         ctNode.setHeader('content-disposition', 'inline');
+        ctNode.setHeader('content-transfer-encoding', '7bit');
         ctNode.filename = 'encrypted.asc';
         ctNode.setContent(ciphertext);
     };

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -158,6 +158,7 @@ define(function(require) {
                     expect(textNode.setContent.calledWith(body)).to.be.true;
                     expect(attmtNode.setContent.calledWith(attmt)).to.be.true;
                     expect(attmtNode.setHeader.calledWith('content-transfer-encoding', 'base64')).to.be.true;
+                    expect(signatureNode.setHeader.calledWith('content-transfer-encoding', '7bit')).to.be.true;
 
                     expect(mail.bodyParts[0].type).to.equal('signed');
                     expect(mail.bodyParts[0].content[0].type).to.equal('text');
@@ -249,6 +250,7 @@ define(function(require) {
                     expect(textNode.setContent.calledWith(body)).to.be.true;
                     expect(attmtNode.setContent.calledWith(attmt)).to.be.true;
                     expect(attmtNode.setHeader.calledWith('content-transfer-encoding', 'base64')).to.be.true;
+                    expect(signatureNode.setHeader.calledWith('content-transfer-encoding', '7bit')).to.be.true;
 
                     expect(signClearStub.calledOnce).to.be.true;
                     expect(readArmoredStub.calledOnce).to.be.true;
@@ -307,11 +309,14 @@ define(function(require) {
                     expect(envelope).to.equal(envelope);
 
                     expect(rootNode.setHeader.calledWith('content-type', 'multipart/encrypted; protocol=application/pgp-encrypted')).to.be.true;
+                    expect(rootNode.setHeader.calledWith('content-transfer-encoding', '7bit')).to.be.true;
                     expect(rootNode.setContent.calledWith('This is an OpenPGP/MIME encrypted message.')).to.be.true;
                     expect(versionNode.setHeader.calledWith('content-description', 'PGP/MIME Versions Identification')).to.be.true;
                     expect(versionNode.setContent.calledWith('Version: 1')).to.be.true;
+                    expect(versionNode.setHeader.calledWith('content-transfer-encoding', '7bit')).to.be.true;
                     expect(ctNode.setHeader.calledWith('content-description', 'OpenPGP encrypted message')).to.be.true;
                     expect(ctNode.setHeader.calledWith('content-disposition', 'inline')).to.be.true;
+                    expect(ctNode.setHeader.calledWith('content-transfer-encoding', '7bit')).to.be.true;
                     expect(ctNode.setContent.calledWith(ct)).to.be.true;
 
                     expect(rootNode.setHeader.calledWith({


### PR DESCRIPTION
Enigmail is unable to extract ciphertext and signature from PGP/MIME messages
for any other encoding than 7bit. See this thread in the mailing list:
https://admin.hostpoint.ch/pipermail/enigmail-users_enigmail.net/2014-August/001963.html
